### PR TITLE
Add pre- and post- version processing which aids yarn publish of plugin to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "test": "tsdx test",
     "lint": "tsdx lint",
     "prepublishOnly": "yarn test",
+    "prepare": "npm run build",
     "postinstall": "jbrowse-plugin-postinstall",
-    "postversion": "git run build && git push --follow-tags"
+    "postversion": "git push --follow-tags"
   },
   "jbrowse-plugin": {
     "name": "MyProject"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mobx-react": "^6.0.0",
     "mobx-state-tree": "3.14.1",
     "react": "^16.8.0",
+    "rimraf": "^3.0.2",
     "rxjs": "^6.0.0",
     "serve": "^11.3.2",
     "tslib": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,16 @@
     "src"
   ],
   "scripts": {
+    "clean": "rimraf dist",
     "start": "tsdx watch --verbose --noClean --format umd --name JBrowsePluginMyProject --onFirstSuccess \"yarn serve --cors --listen 9000 .\"",
+    "prebuild": "npm run clean",
     "build": "tsdx build --format cjs,esm,umd --name JBrowsePluginMyProject",
     "test": "tsdx test",
     "lint": "tsdx lint",
     "prepublishOnly": "yarn test",
-    "postinstall": "jbrowse-plugin-postinstall"
+    "postinstall": "jbrowse-plugin-postinstall",
+    "preversion": "npm run build",
+    "postversion": "git push --follow-tags"
   },
   "jbrowse-plugin": {
     "name": "MyProject"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "lint": "tsdx lint",
     "prepublishOnly": "yarn test",
     "postinstall": "jbrowse-plugin-postinstall",
-    "preversion": "npm run build",
-    "postversion": "git push --follow-tags"
+    "postversion": "git run build && git push --follow-tags"
   },
   "jbrowse-plugin": {
     "name": "MyProject"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,7 +1149,7 @@
   resolved "https://registry.yarnpkg.com/@librpc/ee/-/ee-1.0.4.tgz#ce73a36279dc4cf93efa43f7e3564ec165947522"
   integrity sha512-vhPlbRwAKQC80h0k74tsOkMKIidZtqlFSOHRzCvC8n7Va9rzMDwpG26Pm84dAt0ZuGK0g1UEfPzxDiYo9ZQBrg==
 
-"@librpc/web@github:rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0":
+"@librpc/web@rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0":
   version "1.1.0"
   resolved "https://codeload.github.com/rbuels/librpc-web/tar.gz/737bb9706762a52a87169a12c9b59fb241febab0"
   dependencies:
@@ -6675,7 +6675,7 @@ rimraf@^2.5.2, rimraf@^2.6.1, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
This adds a couple things seen while trying to release to npm

Basically takes a lightweight approach to what is in @GMOD/bam
1) It does not run the build step during yarn publish, so now preversion: runs yarn build
2) It does a clean using rimraf
3) It does clean with prebuild step
4) With postversion it pushes back to github, also what is in @gmod/bam
