### PR TITLE
 Disable unused* in tsconfig in favor of lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,14 @@ module.exports = {
     "react": {
       "version": "detect"
     }
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "args": "after-used",
+        "ignoreRestSiblings": true
+      }
+    ],
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "setup": "node scripts/setup.js && npm run browse-install",
     "clean": "rimraf dist",
-    "start": "tsdx watch --verbose --noClean --format umd --name JBrowsePluginMyProject --onFirstSuccess \"yarn serve --cors --listen 9000 .\"",
+    "start": "tsdx watch --verbose --noClean --format umd --name JBrowsePluginMyProject --onFirstSuccess \"serve --cors --listen 9000 .\"",
     "prebuild": "npm run clean",
     "build": "tsdx build --format cjs,esm,umd --name JBrowsePluginMyProject",
     "browse-install": "cd .jbrowse && rm -rf * && jbrowse create .",
@@ -24,7 +24,7 @@
     "e2e": "start-test start 9000 browse 5000 test:cy",
     "cypress": "cypress open",
     "lint": "tsdx lint",
-    "prepublishOnly": "yarn test",
+    "prepublishOnly": "npm test",
     "prepare": "npm run build",
     "postinstall": "jbrowse-plugin-postinstall",
     "postversion": "git push --follow-tags"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement


### PR DESCRIPTION
Fixes #3. This way, unused variables or arguments don't stop TypeScript from building, but developers can add a lint pre-commit hook, CI check, etc. if they want to check for unused vars/args.

Also adds a small fix so that people running with npm instead of yarn don't get error from the package.json scripts.