### PR TITLE
Add name to package.json so yarn succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "version": "0.0.1",
+  "name": "jbrowse-plugin-my-project",
   "keywords": [
     "jbrowse",
     "jbrowse2"


### PR DESCRIPTION
Without this just running `yarn` does not succeed


We get this

```
yarn install v1.22.10
[1/4] Resolving packages...
success Already up-to-date.
$ jbrowse-plugin-postinstall
patch-package 6.2.2
Applying patches...
tsdx@0.14.1 ✔
$ npm run build

> prebuild
> npm run clean


> clean
> rimraf dist


> build
> tsdx build --format cjs,esm,umd --name JBrowsePluginMyProject

/home/cdiesh/template2/node_modules/tsdx/dist/utils.js:14
    .toLowerCase()
     ^

TypeError: Cannot read property 'toLowerCase' of undefined
    at Object.exports.safePackageName (/home/cdiesh/template2/node_modules/tsdx/dist/utils.js:14:6)
    at Object.createRollupConfig (/home/cdiesh/template2/node_modules/tsdx/dist/createRollupConfig.js:33:49)
    at async /home/cdiesh/template2/node_modules/tsdx/dist/createBuildConfigs.js:24:24
    at async Promise.all (index 0)
    at async Object.createBuildConfigs (/home/cdiesh/template2/node_modules/tsdx/dist/createBuildConfigs.js:22:12)
    at async /home/cdiesh/template2/node_modules/tsdx/dist/index.js:294:26
npm ERR! code 1
npm ERR! path /home/cdiesh/template2
npm ERR! command failed
npm ERR! command sh -c tsdx build --format cjs,esm,umd --name JBrowsePluginMyPr
```

Without it

Following the README you might be able to fix this issue but I think it is helpful to have yarn succeed