### PR TITLE
Icons error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "version": "0.0.1",
+  "name": "jbrowse-plugin-my-project",
   "keywords": [
     "jbrowse",
     "jbrowse2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
       "<rootDir>/cypress/"
     ]
   },
-  "dependencies": {},
+  "dependencies": {
+    "@material-ui/icons": "^4.11.2"
+  },
   "peerDependencies": {
     "@jbrowse/core": "^1.0.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import PluginManager from '@jbrowse/core/PluginManager'
 import { isAbstractMenuManager } from '@jbrowse/core/util'
 import { version } from '../package.json'
 import { ReactComponent } from './HelloView'
+import EmojiEmotionsIcon from '@material-ui/icons/EmojiEmotions'
 
 export default class MyProjectPlugin extends Plugin {
   name = 'MyProject'
@@ -31,6 +32,7 @@ export default class MyProjectPlugin extends Plugin {
       // @ts-ignore
       pluginManager.rootModel.appendToSubMenu(['File', 'Add'], {
         label: 'Open Hello!',
+        icon: EmojiEmotionsIcon,
         // @ts-ignore
         onClick: session => {
           session.addView('HelloView', {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,7 +1247,7 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
-"@material-ui/icons@^4.0.0":
+"@material-ui/icons@^4.0.0", "@material-ui/icons@^4.11.2":
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
   integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==


### PR DESCRIPTION
Usage of @material-ui/icons produces



```
Error: 'ForwardRef' is not exported by node_modules/@material-ui/utils/node_modules/react-is/index.js, imported by node_modules/@material-ui/utils/esm/getDisplayName.js

at /home/cdiesh/template2/node_modules/@material-ui/utils/esm/getDisplayName.js:2:9

1: import _typeof from "@babel/runtime/helpers/esm/typeof";
2: import { ForwardRef, Memo } from 'react-is'; // Simplified polyfill for IE 11 support
            ^
3: // https://github.com/JamesMGreene/Function.name/blob/58b314d4a983110c3682f1228f845d39ccca1817/Function.name.js#L3



```

Mentioned this to @garrettjstevens yesterday but a minimal reproducible use case is here https://github.com/GMOD/jbrowse-plugin-template/tree/icons_error