### PR TITLE
Bump minimum jbrowse core version, fixes #12

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@jbrowse/core": "^1.0.3"
+    "@jbrowse/core": "^1.0.4"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.10.4",
     "@jbrowse/cli": "^1.0.3",
-    "@jbrowse/core": "^1.0.3",
+    "@jbrowse/core": "^1.0.4",
     "@jbrowse/development-tools": "^1.0.3",
     "@material-ui/core": "^4.9.13",
     "@material-ui/lab": "^4.0.0-alpha.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,10 +1009,10 @@
     tslib "^1"
     unzipper "^0.10.11"
 
-"@jbrowse/core@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@jbrowse/core/-/core-1.0.3.tgz#b4b023e58d41fcf061d60f4c52f995144f6d7571"
-  integrity sha512-Xl/3Wqi6wJkDgfK89oKCVJ01BRWbs3o5oYDfygH2aDy9A/AqDFMRpBCezXGdhUxiPte8KzTx/moXChFTtWNXOw==
+"@jbrowse/core@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jbrowse/core/-/core-1.0.4.tgz#76a2158c028bd224a37e7a2ccfc4c381ff3f582e"
+  integrity sha512-qElLDOmXcGq/m/RBwVYlfrWXAuoTpj3FvSx4ylVobgzMyCkebnP/7Tf+vhWpu08OSTfIVZdABvugLIsVrXlNPw==
   dependencies:
     "@librpc/web" rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0
     "@material-ui/icons" "^4.0.0"
@@ -1223,7 +1223,7 @@
   resolved "https://registry.yarnpkg.com/@librpc/ee/-/ee-1.0.4.tgz#ce73a36279dc4cf93efa43f7e3564ec165947522"
   integrity sha512-vhPlbRwAKQC80h0k74tsOkMKIidZtqlFSOHRzCvC8n7Va9rzMDwpG26Pm84dAt0ZuGK0g1UEfPzxDiYo9ZQBrg==
 
-"@librpc/web@rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0":
+"@librpc/web@github:rbuels/librpc-web#737bb9706762a52a87169a12c9b59fb241febab0":
   version "1.1.0"
   resolved "https://codeload.github.com/rbuels/librpc-web/tar.gz/737bb9706762a52a87169a12c9b59fb241febab0"
   dependencies:


### PR DESCRIPTION
Fixes #12 by bumping up the minimum version of `@jbrowse/core`