### PR TITLE
Remove jbrequire usage and code style updates

### DIFF
--- a/src/HelloView/components/ReactComponent.tsx
+++ b/src/HelloView/components/ReactComponent.tsx
@@ -7,7 +7,7 @@ export default function ReactComponent() {
       <h1>Hello plugin developers!</h1>
       <button
         onClick={() => {
-          setPushed('Woah! You pushed the button!')
+          setPushed('Whoa! You pushed the button!')
         }}
       >
         Push the button

--- a/src/HelloView/index.ts
+++ b/src/HelloView/index.ts
@@ -1,1 +1,2 @@
 export { default as ReactComponent } from './components/ReactComponent'
+export { default as stateModel } from './stateModel'

--- a/src/HelloView/stateModel.ts
+++ b/src/HelloView/stateModel.ts
@@ -1,0 +1,10 @@
+import { types } from 'mobx-state-tree'
+
+const stateModel = types
+  .model({ type: types.literal('HelloView') })
+  .actions(() => ({
+    // unused but required by your view
+    setWidth() {},
+  }))
+
+export default stateModel

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,24 @@
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
+import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
 import { isAbstractMenuManager } from '@jbrowse/core/util'
 import { version } from '../package.json'
-import { ReactComponent } from './HelloView'
+import {
+  ReactComponent as HelloViewReactComponent,
+  stateModel as helloViewStateModel,
+} from './HelloView'
 
 export default class MyProjectPlugin extends Plugin {
   name = 'MyProject'
   version = version
 
   install(pluginManager: PluginManager) {
-    const { jbrequire } = pluginManager
-    const { types } = pluginManager.lib['mobx-state-tree']
-
-    const ViewType = jbrequire('@jbrowse/core/pluggableElementTypes/ViewType')
-    const stateModel = types
-      .model({ type: types.literal('HelloView') })
-      .actions(() => ({
-        setWidth() {
-          // unused but required by your view
-        },
-      }))
-
     pluginManager.addViewType(() => {
-      return new ViewType({ name: 'HelloView', stateModel, ReactComponent })
+      return new ViewType({
+        name: 'HelloView',
+        stateModel: helloViewStateModel,
+        ReactComponent: HelloViewReactComponent,
+      })
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Plugin from '@jbrowse/core/Plugin'
 import PluginManager from '@jbrowse/core/PluginManager'
 import ViewType from '@jbrowse/core/pluggableElementTypes/ViewType'
-import { isAbstractMenuManager } from '@jbrowse/core/util'
+import { AbstractSessionModel, isAbstractMenuManager } from '@jbrowse/core/util'
 import { version } from '../package.json'
 import {
   ReactComponent as HelloViewReactComponent,
@@ -24,11 +24,9 @@ export default class MyProjectPlugin extends Plugin {
 
   configure(pluginManager: PluginManager) {
     if (isAbstractMenuManager(pluginManager.rootModel)) {
-      // @ts-ignore
       pluginManager.rootModel.appendToSubMenu(['File', 'Add'], {
         label: 'Open Hello!',
-        // @ts-ignore
-        onClick: session => {
+        onClick: (session: AbstractSessionModel) => {
           session.addView('HelloView', {})
         },
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2470,9 +2470,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001173:
-  version "1.0.30001174"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001174.tgz#0f2aca2153fd88ceb07a2bb982fc2acb787623c4"
-  integrity sha512-tqClL/4ThQq6cfFXH3oJL4rifFBeM6gTkphjao5kgwMaW9yn0tKgQLAEfKzDwj6HQWCB/aWo8kTFlSvIN8geEA==
+  version "1.0.30001252"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz"
+  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
 
 canvas@^2.5.0:
   version "2.6.1"


### PR DESCRIPTION
This removes the usage `jbrequire` since it isn't needed with the current build system. It also splits the HelloView's stateModel into a separate file so that organizationally it's more like established JBrowse plugins. Also avoid a couple ts-ignores.