### PR TITLE
Add NODE_ENV=development to watcher 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:jbrowse:create": "jbrowse create .jbrowse",
     "clean": "rimraf dist",
     "start": "npm-run-all --sequential clean --parallel start:*",
-    "start:watch": "cross-env JB_NPM=false rollup --config --watch",
+    "start:watch": "cross-env NODE_ENV=development JB_NPM=false rollup --config --watch",
     "start:server": "serve --cors --listen $npm_package_config_port .",
     "prebuild": "npm-run-all clean",
     "build": "rollup --config",


### PR DESCRIPTION
fixes https://github.com/GMOD/jbrowse-plugin-template/issues/37

Note:
I also ran into some weird things where I needed to use @rollup/plugin-replace to replace NODE_ENV but this might just be for my particular weird molstar plugin

this was my config to replace NODE_ENV, but this PR does not include this

```
replace({
      preventAssignment: true,
      values: {
        'process.env.NODE_ENV': JSON.stringify('production'),
      },
    }),
```

that could be a separate issue though