### PR TITLE
Fix setup instructions for Yarn 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ project.
 
 - [git](https://git-scm.com/downloads)
 - [Node.js](https://nodejs.org/en/download/) (version 10 or greater)
-- [yarn](https://yarnpkg.com/en/docs/install) (or npm which comes with Node.js)
+- npm (which comes with Node.js)
+- [yarn](https://yarnpkg.com/en/docs/install) (optional)
 - [JBrowse 2](https://github.com/gmod/jbrowse-components) (version 2.0 or
   greater)
 
@@ -42,17 +43,17 @@ $ git init
 
 ### Setup
 
-Run `yarn init` (or `npm init`) and answer the prompts to fill out the
-information for your plugin
+Run `npm init` and answer the prompts to fill out the information for your
+plugin:
 
 - Make sure you at least enter a "name" (probably starting with
   "jbrowse-plugin-", or "@myscope/jbrowse-plugin-" if you're going to publish to
   an NPM organization)
 - Other fields may be left blank
-- leave the "entry point" as `dist/index.js`
+- Leave the "entry point" as `dist/index.js`
 
-Now run `yarn` (or `rm yarn.lock && npm install` to use npm instead of yarn) to
-install the necessary dependencies.
+Now run `yarn` (or `npm install` to use npm instead of yarn) to install the
+necessary dependencies.
 
 After this, run `yarn setup` (or `npm run setup`). This configures your project,
 and adds a build of JBrowse 2 that can be used to test your plugin during
@@ -189,3 +190,4 @@ JavaScript for development. If using only JavaScript, you can change
 If using only TypeScript, you can remove `"allowJs": true` from `tsconfig.json`
 and `"@babel/preset-react"` from `.babelrc` (and from "devDependencies" in
 `package.json`).
+


### PR DESCRIPTION
Yarn 2.0 and newer versions do not ask questions about the package metadata during `yarn init`. Therefore, `npm init` should be used even with Yarn.